### PR TITLE
trait dispatch optimisation pass

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -407,6 +407,18 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_methods_count = 0;
 	}
 
+	if (native_impl_call_function_map.size()) {
+		function->native_impl_call_functions.resize(native_impl_call_function_map.size());
+		function->_native_impl_call_functions_ptr = function->native_impl_call_functions.ptrw();
+		function->_native_impl_call_functions_count = native_impl_call_function_map.size();
+		for (const KeyValue<GDScriptFunction*, int>& E : native_impl_call_function_map) {
+			function->native_impl_call_functions.write[E.value] = E.key;
+		}
+	} else {
+		function->_native_impl_call_functions_ptr = nullptr;
+		function->_native_impl_call_functions_count = 0;
+	}
+
 	if (lambdas_map.size()) {
 		function->lambdas.resize(lambdas_map.size());
 		function->_lambdas_ptr = function->lambdas.ptrw();
@@ -1410,7 +1422,21 @@ void GDScriptByteCodeGenerator::write_call_method_bind_validated(const Address &
 	ct.cleanup();
 }
 
-void GDScriptByteCodeGenerator::write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {
+void GDScriptByteCodeGenerator::write_call_native_impl_cached(const Address& p_target, const Address& p_base, GDScriptFunction* p_function, const Vector<Address>& p_arguments) {
+	DEV_ASSERT(p_function != nullptr);
+	append_opcode_and_argcount(p_target.mode == Address::NIL ? GDScriptFunction::OPCODE_CALL_NATIVE_IMPL_CACHED : GDScriptFunction::OPCODE_CALL_NATIVE_IMPL_CACHED_RET, 2 + p_arguments.size());
+	for (int i = 0; i < p_arguments.size(); i++) {
+		append(p_arguments[i]);
+	}
+	append(p_base);
+	CallTarget ct = get_call_target(p_target);
+	append(ct.target);
+	append(p_arguments.size());
+	append_native_impl_call_function(p_function);
+	ct.cleanup();
+}
+
+void GDScriptByteCodeGenerator::write_call_self(const Address& p_target, const StringName& p_function_name, const Vector<Address>& p_arguments) {
 	if (p_target.mode == Address::NIL) {
 		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL, 2 + p_arguments.size());
 		for (int i = 0; i < p_arguments.size(); i++) {
@@ -1456,7 +1482,7 @@ void GDScriptByteCodeGenerator::write_lambda(const Address &p_target, GDScriptFu
 	CallTarget ct = get_call_target(p_target);
 	append(ct.target);
 	append(p_captures.size());
-	append(p_function);
+	append_lambda(p_function);
 	ct.cleanup();
 }
 

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -115,6 +115,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	RBMap<GDScriptUtilityFunctions::FunctionPtr, int> gds_utilities_map;
 	RBMap<MethodBind *, int> method_bind_map;
 	RBMap<GDScriptFunction *, int> lambdas_map;
+	RBMap<GDScriptFunction*, int> native_impl_call_function_map;
 
 #ifdef DEBUG_ENABLED
 	// Keep method and property names for pointer and validated operations.
@@ -337,6 +338,15 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 		return pos;
 	}
 
+	int get_native_impl_call_function_pos(GDScriptFunction* p_function) {
+		if (native_impl_call_function_map.has(p_function)) {
+			return native_impl_call_function_map[p_function];
+		}
+		int pos = native_impl_call_function_map.size();
+		native_impl_call_function_map[p_function] = pos;
+		return pos;
+	}
+
 	int get_lambda_function_pos(GDScriptFunction *p_lambda_function) {
 		if (lambdas_map.has(p_lambda_function)) {
 			return lambdas_map[p_lambda_function];
@@ -440,8 +450,12 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 		opcodes.push_back(get_method_bind_pos(p_method));
 	}
 
-	void append(GDScriptFunction *p_lambda_function) {
+	void append_lambda(GDScriptFunction *p_lambda_function) {
 		opcodes.push_back(get_lambda_function_pos(p_lambda_function));
+	}
+
+	void append_native_impl_call_function(GDScriptFunction* p_function) {
+		opcodes.push_back(get_native_impl_call_function_pos(p_function));
 	}
 
 	void patch_jump(int p_address) {
@@ -519,6 +533,7 @@ public:
 	virtual void write_call_native_static_validated(const Address &p_target, MethodBind *p_method, const Vector<Address> &p_arguments) override;
 	virtual void write_call_method_bind(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) override;
 	virtual void write_call_method_bind_validated(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) override;
+	virtual void write_call_native_impl_cached(const Address& p_target, const Address& p_base, GDScriptFunction* p_function, const Vector<Address>& p_arguments) override;
 	virtual void write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
 	virtual void write_call_self_async(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) override;
 	virtual void write_lambda(const Address &p_target, GDScriptFunction *p_function, const Vector<Address> &p_captures, bool p_use_self) override;

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -133,6 +133,7 @@ public:
 	virtual void write_call_native_static_validated(const Address &p_target, MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
 	virtual void write_call_method_bind(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
 	virtual void write_call_method_bind_validated(const Address &p_target, const Address &p_base, MethodBind *p_method, const Vector<Address> &p_arguments) = 0;
+	virtual void write_call_native_impl_cached(const Address& p_target, const Address& p_base, GDScriptFunction* p_function, const Vector<Address>& p_arguments) = 0;
 	virtual void write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
 	virtual void write_call_self_async(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) = 0;
 	virtual void write_lambda(const Address &p_target, GDScriptFunction *p_function, const Vector<Address> &p_captures, bool p_use_self) = 0;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -30,12 +30,11 @@
 
 #include "gdscript_compiler.h"
 
-#include "gdscript_trait_analyzer.h"
-
 #include "gdscript.h"
 #include "gdscript_analyzer.h"
 #include "gdscript_byte_codegen.h"
 #include "gdscript_cache.h"
+#include "gdscript_trait_analyzer.h"
 #include "gdscript_utility_functions.h"
 
 #include "core/config/engine.h"
@@ -739,16 +738,26 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 											gen->write_call_method_bind(result, base, method, arguments);
 										}
 									} else {
-										gen->write_call(result, base, call->function_name, arguments);
+										GDScriptCache::ensure_global_impls_scanned();
+										if (GDScriptFunction* impl_function = GDScriptLanguage::get_singleton()->find_native_class_impl_method_cached(class_name, call->function_name)) {
+											gen->write_call_native_impl_cached(result, base, impl_function, arguments);
+										} else {
+											gen->write_call(result, base, call->function_name, arguments);
+										}
 									}
 								} else if (base.type.kind == GDScriptDataType::BUILTIN) {
 									if (Variant::has_builtin_method(base.type.builtin_type, call->function_name)) {
 										gen->write_call_builtin_type(result, base, base.type.builtin_type, call->function_name, arguments);
 									} else {
-										///not a real Variant builtin method, likely an `impl` method on a builtin type
-										///fallback to dynamic dispatch, which knows how to fuck with native impl methods
-										///via GDScriptLanguage::get_native_impl_method() at runtime
-										gen->write_call(result, base, call->function_name, arguments);
+										GDScriptCache::ensure_global_impls_scanned();
+										if (GDScriptFunction* impl_function = GDScriptLanguage::get_singleton()->get_native_impl_method(base.type.builtin_type, call->function_name)) {
+											gen->write_call_native_impl_cached(result, base, impl_function, arguments);
+										} else {
+											///not a real Variant builtin method, likely an `impl` method on a builtin type.
+											///fallback to dynamic dispatch, which knows how to fuck with native impl methods
+											///via GDScriptLanguage::get_native_impl_method() at runtime
+											gen->write_call(result, base, call->function_name, arguments);
+										}
 									}
 								} else {
 									gen->write_call(result, base, call->function_name, arguments);
@@ -2941,7 +2950,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 						}
 						prop_info.usage |= resolved_type_info.usage;
 					}
-					
+
 				} else {
 					// Enum hint doesn't really belong to the data type information, so we don't want to add it to
 					// `GDScriptParser::DataType::to_property_info()`. However, we still want to add this metadata

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -832,7 +832,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 					text += DADDR(1 + i);
 				}
 				text += ")";
-				incr = 4 + argc;
+				incr = 5 + argc;
 			} break;
 
 			case OPCODE_CALL_NATIVE_STATIC_VALIDATED_NO_RETURN: {
@@ -892,6 +892,31 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += method->get_name();
 				text += "(";
 
+				for (int i = 0; i < argc; i++) {
+					if (i > 0) {
+						text += ", ";
+					}
+					text += DADDR(1 + i);
+				}
+				text += ")";
+
+				incr = 5 + argc;
+			} break;
+
+			case OPCODE_CALL_NATIVE_IMPL_CACHED:
+			case OPCODE_CALL_NATIVE_IMPL_CACHED_RET: {
+				bool call_ret = _code_ptr[ip] == OPCODE_CALL_NATIVE_IMPL_CACHED_RET;
+				int instr_var_args = _code_ptr[++ip];
+				int argc = _code_ptr[ip + 1 + instr_var_args];
+				GDScriptFunction* function = _native_impl_call_functions_ptr[_code_ptr[ip + 2 + instr_var_args]];
+
+				text += call_ret ? "call native-impl cached (return) " : "call native-impl cached (no return) ";
+				if (call_ret) {
+					text += DADDR(2 + argc) + " = ";
+				}
+				text += DADDR(1 + argc) + ".";
+				text += function != nullptr ? String(function->get_name()) : String("<null>");
+				text += "(";
 				for (int i = 0; i < argc; i++) {
 					if (i > 0) {
 						text += ", ";

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -206,6 +206,8 @@ public:
 		OPCODE_CALL_NATIVE_STATIC_VALIDATED_NO_RETURN,
 		OPCODE_CALL_METHOD_BIND_VALIDATED_RETURN,
 		OPCODE_CALL_METHOD_BIND_VALIDATED_NO_RETURN,
+		OPCODE_CALL_NATIVE_IMPL_CACHED,
+		OPCODE_CALL_NATIVE_IMPL_CACHED_RET,
 		OPCODE_AWAIT,
 		OPCODE_AWAIT_RESUME,
 		OPCODE_CREATE_LAMBDA,
@@ -404,6 +406,7 @@ private:
 	Vector<GDScriptUtilityFunctions::FunctionPtr> gds_utilities;
 	Vector<MethodBind *> methods;
 	Vector<GDScriptFunction *> lambdas;
+	Vector<GDScriptFunction*> native_impl_call_functions;
 
 	int _code_size = 0;
 	int _default_arg_count = 0;
@@ -421,6 +424,7 @@ private:
 	int _utilities_count = 0;
 	int _gds_utilities_count = 0;
 	int _methods_count = 0;
+	int _native_impl_call_functions_count = 0;
 	int _lambdas_count = 0;
 
 	int *_code_ptr = nullptr;
@@ -440,6 +444,7 @@ private:
 	const GDScriptUtilityFunctions::FunctionPtr *_gds_utilities_ptr = nullptr;
 	MethodBind **_methods_ptr = nullptr;
 	GDScriptFunction **_lambdas_ptr = nullptr;
+	GDScriptFunction** _native_impl_call_functions_ptr = nullptr;
 
 #ifdef DEBUG_ENABLED
 	CharString func_cname;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -31,8 +31,8 @@
 #include "gdscript.h"
 #include "gdscript_cache.h"
 #include "gdscript_function.h"
-#include "gdscript_lambda_callable.h"
 #include "gdscript_impl_callable.h"
+#include "gdscript_lambda_callable.h"
 
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -426,6 +426,8 @@ void (*type_init_function_table[])(Variant *) = {
 		&&OPCODE_CALL_NATIVE_STATIC_VALIDATED_NO_RETURN, \
 		&&OPCODE_CALL_METHOD_BIND_VALIDATED_RETURN, \
 		&&OPCODE_CALL_METHOD_BIND_VALIDATED_NO_RETURN, \
+		&&OPCODE_CALL_NATIVE_IMPL_CACHED, \
+		&&OPCODE_CALL_NATIVE_IMPL_CACHED_RET, \
 		&&OPCODE_AWAIT, \
 		&&OPCODE_AWAIT_RESUME, \
 		&&OPCODE_CREATE_LAMBDA, \
@@ -2311,7 +2313,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						///uses to prepend captures ahead of the real call arguments
 						///i love being unoriginal
 						const int total_argc = argc + 1;
-						const Variant** impl_argptrs = (const Variant**)alloca(sizeof(Variant*)* total_argc);
+						const Variant* small_impl_argptrs[5];
+						const Variant** impl_argptrs = total_argc <= 5 ? small_impl_argptrs : (const Variant** )alloca(sizeof(Variant*)* total_argc);
 						impl_argptrs[0] = base;
 						for (int i = 0; i < argc; i++) {
 							impl_argptrs[i + 1] = argptrs[i];
@@ -2356,7 +2359,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				} else {
 					if (native_impl_function != nullptr) {
 						const int total_argc = argc + 1;
-						const Variant** impl_argptrs = (const Variant**)alloca(sizeof(Variant*)* total_argc);
+						const Variant* small_impl_argptrs[5];
+						const Variant** impl_argptrs = total_argc <= 5 ? small_impl_argptrs : (const Variant**) alloca(sizeof(Variant*)* total_argc);
 						impl_argptrs[0] = base;
 						for (int i = 0; i < argc; i++) {
 							impl_argptrs[i + 1] = argptrs[i];
@@ -2420,6 +2424,58 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				}
 #endif // DEBUG_ENABLED
 
+				ip += 3;
+			}
+			DISPATCH_OPCODE;
+
+			OPCODE(OPCODE_CALL_NATIVE_IMPL_CACHED)
+			OPCODE(OPCODE_CALL_NATIVE_IMPL_CACHED_RET) {
+				bool call_ret = (_code_ptr[ip]) == OPCODE_CALL_NATIVE_IMPL_CACHED_RET;
+				LOAD_INSTRUCTION_ARGS
+				CHECK_SPACE(3 + instr_arg_count);
+
+				ip += instr_arg_count;
+
+				int argc = _code_ptr[ip + 1];
+				GD_ERR_BREAK(argc < 0);
+				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _native_impl_call_functions_count);
+				GDScriptFunction* native_impl_function = _native_impl_call_functions_ptr[_code_ptr[ip + 2]];
+#ifdef DEBUG_ENABLED
+				if (native_impl_function == nullptr) {
+					err_text = "[Reginleif] compiler bug!!, cached native impl function is null?!";
+					OPCODE_BREAK;
+				}
+#endif
+
+				GET_INSTRUCTION_ARG(base, argc);
+				Variant** argptrs = instruction_args;
+
+				const int total_argc = argc + 1;
+				const Variant* small_impl_argptrs[5];
+				const Variant** impl_argptrs = total_argc <= 5 ? small_impl_argptrs : (const Variant**) alloca(sizeof(Variant*)* total_argc);
+				impl_argptrs[0] = base;
+				for (int i = 0; i < argc; i++) {
+					impl_argptrs[i + 1] = argptrs[i];
+				}
+
+				Variant temp_ret;
+				Callable::CallError err;
+				if (call_ret) {
+					GET_INSTRUCTION_ARG(ret, argc + 1);
+					temp_ret = native_impl_function->call(nullptr, impl_argptrs, total_argc, err);
+					*ret = temp_ret;
+				} else {
+					temp_ret = native_impl_function->call(nullptr, impl_argptrs, total_argc, err);
+				}
+
+#ifdef DEBUG_ENABLED
+				if (err.error != Callable::CallError::CALL_OK) {
+					String methodstr = native_impl_function->get_name();
+					String basestr = _get_var_type(base);
+					err_text = _get_call_error("impl function '" + methodstr + "' in base '" + basestr + "'", impl_argptrs, total_argc, temp_ret, err);
+					OPCODE_BREAK;
+				}
+#endif
 				ip += 3;
 			}
 			DISPATCH_OPCODE;


### PR DESCRIPTION
so we do a few things here. the first is that we build a dedicated ass machine for trait dispatch, and by that i mean we make a few dedicated opcodes (stuff was just dyn dispatched all the time before, and we still paid the perf price EVEN THOUGH we were caching the func ptrs!!! what the genuine fuck, how crazy is that :sob:), and that dramatically reduced a ton of the call overhead, and next we added a teeeny tiny optimisation, that is, now we maintain dedicated pointers instead of doing `alloca` for function calls with small arity (<=4), it improved things nontrivially, so i'd call that a wrap for now :>
