### PR TITLE
remove the need for \ when chaining methods across lines

### DIFF
--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1320,6 +1320,39 @@ String GDScriptTokenizerText::_get_indent_char_name(char32_t ch) {
 	return ch == ' ' ? "space" : "tab";
 }
 
+bool GDScriptTokenizerText::_peek_next_line_starts_with_period() {
+	int offset = 0;
+	for (;;) {
+		char32_t c = _peek(offset);
+		if (c == ' ' || c == '\t' || c == '\r') {
+			offset++;
+			continue;
+		}
+		if (c == '\n') {
+			offset++;
+			continue;
+		}
+		if (c == '#') {
+			while (true) {
+				char32_t cc = _peek(offset);
+				if (cc == '\0' || cc == '\n') {
+					break;
+				}
+				offset++;
+			}
+			continue;
+		}
+		if (c == '.') {
+			char32_t c1 = _peek(offset + 1);
+			if (c1 == '.') {
+				return false;
+			}
+			return is_unicode_identifier_start(c1);
+		}
+		return false;
+	}
+}
+
 void GDScriptTokenizerText::_skip_whitespace() {
 	if (pending_indents != 0) {
 		// Still have some indent/dedent tokens to give.
@@ -1349,6 +1382,12 @@ void GDScriptTokenizerText::_skip_whitespace() {
 				break;
 			case '\n':
 				_advance();
+				if (!is_bol && _peek_next_line_starts_with_period()) {
+					newline(false);
+					line_continuation = true;
+					continuation_lines.push_back(line);
+					break;
+				}
 				newline(!is_bol); // Don't create new line token if line is empty.
 				check_indent();
 				break;

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -274,6 +274,7 @@ class GDScriptTokenizerText : public GDScriptTokenizer {
 	char32_t _advance();
 	String _get_indent_char_name(char32_t ch);
 	void _skip_whitespace();
+	bool _peek_next_line_starts_with_period();
 	void check_indent();
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_tokenizer_buffer.h
+++ b/modules/gdscript/gdscript_tokenizer_buffer.h
@@ -39,7 +39,7 @@ public:
 		COMPRESS_ZSTD,
 	};
 
-	static constexpr uint32_t TOKENIZER_VERSION = 101;
+	static constexpr uint32_t TOKENIZER_VERSION = 102;
 	static constexpr uint32_t TOKEN_BYTE_MASK = 0x80;
 	static constexpr uint32_t TOKEN_BITS = 8;
 	static constexpr uint32_t TOKEN_MASK = (1 << (TOKEN_BITS - 1)) - 1;


### PR DESCRIPTION
imagine:
```gdscript
stage                          \
  .query()                     \
  .both_sides()                \
  .and_then(draw_2)
```

this is especially annoying because of the `\`. now it is no longer needed when the next token on the new line is a dot. so you can just do:

```gdscript
stage                          
  .query()                     
  .both_sides()                
  .and_then(draw_2)
```