### PR TITLE
implement type narrowing for conditionals in the analyser

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3417,13 +3417,113 @@ bool GDScriptAnalyzer::resolve_generic_bound_chain(const StringName& p_generic_p
     return true; ///chased something concrete and constrained! yay!
 }
 
+///returns true iff every control flow path through this ends in a return
+static bool suite_always_exits(const GDScriptParser::SuiteNode* p_suite) {
+	if (p_suite == nullptr || p_suite->statements.is_empty()) {
+		return false;
+	}
+	const GDScriptParser::Node* last = p_suite->statements[p_suite->statements.size() - 1];
+	if (last->type == GDScriptParser::Node::RETURN || last->type == GDScriptParser::Node::BREAK || last->type == GDScriptParser::Node::CONTINUE) {
+		return true;
+	}
+	if (last->type == GDScriptParser::Node::IF) {
+		const GDScriptParser::IfNode* if_node = static_cast<const GDScriptParser::IfNode*>(last); ///just let me auto...
+		if (if_node->false_block == nullptr) {
+			return false;
+		}
+		return suite_always_exits(if_node->true_block) && suite_always_exits(if_node->false_block);
+	}
+	return false;
+}
+
+void GDScriptAnalyzer::collect_type_narrowing(GDScriptParser::ExpressionNode* p_expr, bool p_positive, NarrowingScope& r_narrowed) {
+	if (p_expr == nullptr) {
+		return;
+	}
+
+	switch (p_expr->type) {
+		case GDScriptParser::Node::TYPE_TEST: {
+
+			GDScriptParser::TypeTestNode *type_test = static_cast<GDScriptParser::TypeTestNode*>(p_expr);
+
+			if (type_test->operand == nullptr || type_test->operand->type != GDScriptParser::Node::IDENTIFIER || !type_test->test_datatype.is_set()) {
+				break;
+			}
+
+			///my fucking blood boils each time i have to do this. 
+			///why can't there be a nuanced auto ban instead of 'nope, no auto!!'
+			///come on man...
+			GDScriptParser::IdentifierNode* id = static_cast<GDScriptParser::IdentifierNode*>(type_test->operand);
+
+			if (id->source == GDScriptParser::IdentifierNode::LOCAL_VARIABLE && id->variable_source != nullptr) {
+				if (p_positive) {
+					r_narrowed.variables.insert(id->variable_source, type_test->test_datatype);
+				}
+			} else if (id->source == GDScriptParser::IdentifierNode::LOCAL_ITERATOR && id->bind_source != nullptr) {
+				if (p_positive) {
+					r_narrowed.iterators.insert(id->bind_source, type_test->test_datatype);
+				}
+			}
+
+			///only local variables and for iterators are narrowed.
+			///member/static/param narrowing is unsafe here
+			///negative narrowing (`x is not Foo`) just literally can't produce a concrete narrower
+			///type in general (the complement of a type isn't expressible as a DataType lmao, fuck CFG semantics)
+			///so no entryfor p_positive == false beyond what NOT/AND compose right below
+			break;
+		}
+
+		case GDScriptParser::Node::UNARY_OPERATOR: {
+			GDScriptParser::UnaryOpNode* unary = static_cast<GDScriptParser::UnaryOpNode*>(p_expr);
+			if (unary->operation == GDScriptParser::UnaryOpNode::OP_LOGIC_NOT) {
+				collect_type_narrowing(unary->operand, !p_positive, r_narrowed);
+			}
+			break;
+		}
+		case GDScriptParser::Node::BINARY_OPERATOR: {
+			GDScriptParser::BinaryOpNode* binary = static_cast<GDScriptParser::BinaryOpNode*>(p_expr);
+			if (binary->operation == GDScriptParser::BinaryOpNode::OP_LOGIC_AND && p_positive) {
+				///`if x is Shit and ...`: narrowing from Shit holds while evaluating '...' and then both hold true
+				collect_type_narrowing(binary->left_operand, true, r_narrowed);
+				collect_type_narrowing(binary->right_operand, true, r_narrowed);
+			}
+			///`Shit or Ass`, and the nonpositive case for `and`, don't yield a sound single
+			///narrowed type, so i genuinely can't be fucked to handle that case
+			break;
+		}
+		default:
+			break;
+	}
+}
+
 void GDScriptAnalyzer::resolve_if(GDScriptParser::IfNode *p_if) {
 	reduce_expression(p_if->condition);
 
-	resolve_suite(p_if->true_block);
+	{
+		NarrowingScope true_narrowed(narrowed_types);
+		collect_type_narrowing(p_if->condition, true, true_narrowed);
+		NarrowingScope saved(narrowed_types);
+
+		///hmm, i wonder why i sneezed while writing this?
+		Finally restore_narrowing([&]() { narrowed_types = saved; }); 
+
+		narrowed_types = true_narrowed;
+		resolve_suite(p_if->true_block);
+	}
 
 	if (p_if->false_block != nullptr) {
+		NarrowingScope false_narrowed(narrowed_types);
+		collect_type_narrowing(p_if->condition, false, false_narrowed);
+		NarrowingScope saved(narrowed_types);
+		Finally restore_narrowing([&]() { narrowed_types = saved; }); 
+		narrowed_types = false_narrowed;
 		resolve_suite(p_if->false_block);
+	}
+
+	///early return propagation case
+	///`if shit is not Ass: return` should narrow shit to Ass here
+	if (p_if->false_block == nullptr && suite_always_exits(p_if->true_block)) {
+		collect_type_narrowing(p_if->condition, false, narrowed_types);
 	}
 }
 
@@ -3539,7 +3639,12 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 		}
 	}
 
-	resolve_suite(p_for->loop);
+	{
+		NarrowingScope saved(narrowed_types);
+		Finally restore_narrowing([&]() { narrowed_types = saved; });
+		resolve_suite(p_for->loop);
+	}
+
 #ifdef DEBUG_ENABLED
 	if (p_for->variable) {
 		is_shadowing(p_for->variable, R"("for" iterator variable)", true);
@@ -3549,6 +3654,13 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 
 void GDScriptAnalyzer::resolve_while(GDScriptParser::WhileNode *p_while) {
 	reduce_expression(p_while->condition);
+
+	NarrowingScope loop_narrowed(narrowed_types);
+	collect_type_narrowing(p_while->condition, true, loop_narrowed);
+	NarrowingScope saved(narrowed_types);
+	Finally restore_narrowing([&]() { narrowed_types = saved; });
+	narrowed_types = loop_narrowed;
+
 	resolve_suite(p_while->loop);
 }
 
@@ -4144,6 +4256,16 @@ void GDScriptAnalyzer::update_dictionary_literal_element_type(GDScriptParser::Di
 void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assignment) {
 	reduce_expression(p_assignment->assigned_value);
 
+	///invalidate narrowing on reassignment
+	if (p_assignment->assignee->type == GDScriptParser::Node::IDENTIFIER) {
+		GDScriptParser::IdentifierNode* narrow_check_id = static_cast<GDScriptParser::IdentifierNode*>(p_assignment->assignee);
+		if (narrow_check_id->source == GDScriptParser::IdentifierNode::LOCAL_VARIABLE && narrow_check_id->variable_source) {
+			narrowed_types.variables.erase(narrow_check_id->variable_source);
+		} else if (narrow_check_id->source == GDScriptParser::IdentifierNode::LOCAL_ITERATOR && narrow_check_id->bind_source) {
+			narrowed_types.iterators.erase(narrow_check_id->bind_source);
+		}
+	}
+
 #ifdef DEBUG_ENABLED
 	// Increment assignment count for local variables.
 	// Before we reduce the assignee because we don't want to warn about not being assigned when performing the assignment.
@@ -4393,7 +4515,19 @@ void GDScriptAnalyzer::reduce_await(GDScriptParser::AwaitNode *p_await) {
 
 void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_op) {
 	reduce_expression(p_binary_op->left_operand);
-	reduce_expression(p_binary_op->right_operand);
+
+	///push a temporary narrow ONLY for the right operand's reduction
+	///this is so that `if shit is Ass and shit.ass()` can be narrowed
+	if (p_binary_op->operation == GDScriptParser::BinaryOpNode::OP_LOGIC_AND) {
+		NarrowingScope right_narrowed(narrowed_types);
+		collect_type_narrowing(p_binary_op->left_operand, true, right_narrowed);
+		NarrowingScope saved(narrowed_types);
+		Finally restore_narrowing([&]() { narrowed_types = saved; });
+		narrowed_types = right_narrowed;
+		reduce_expression(p_binary_op->right_operand);
+	} else {
+		reduce_expression(p_binary_op->right_operand);
+	}
 
 	GDScriptParser::DataType left_type;
 	if (p_binary_op->left_operand) {
@@ -6211,6 +6345,14 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 			[[fallthrough]];
 		case GDScriptParser::IdentifierNode::LOCAL_VARIABLE:
 			p_identifier->variable_source->usages++;
+
+			///use narrows if found
+			if (const GDScriptParser::DataType* narrowed = narrowed_types.variables.getptr(p_identifier->variable_source)) {
+				p_identifier->type_constraint = *narrowed;
+				found_source = true;
+				break;
+			}
+
 			[[fallthrough]];
 		case GDScriptParser::IdentifierNode::STATIC_VARIABLE:
 			p_identifier->type_constraint = p_identifier->variable_source->type_constraint;
@@ -6222,9 +6364,16 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 #endif // DEBUG_ENABLED
 			break;
 		case GDScriptParser::IdentifierNode::LOCAL_ITERATOR:
+		
+			p_identifier->bind_source->usages++;	
+			if (const GDScriptParser::DataType* narrowed = narrowed_types.iterators.getptr(p_identifier->bind_source)) {
+				p_identifier->type_constraint = *narrowed;
+				found_source = true;
+				break;
+			}
+			
 			p_identifier->type_constraint = p_identifier->bind_source->type_constraint;
 			found_source = true;
-			p_identifier->bind_source->usages++;
 			break;
 		case GDScriptParser::IdentifierNode::LOCAL_BIND: {
 			GDScriptParser::DataType result = p_identifier->bind_source->type_constraint;

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -62,6 +62,15 @@ class GDScriptAnalyzer {
 	bool static_context = false;
 	GDScriptParser::DataType current_impl_self_type;
 
+	///who the FUCK thought it was a brilliant idea to make the iterator its own identifier node
+	///COMPLETELY disjoint from a local variable
+	///(seriously though, what does this get you :sob:)
+	struct NarrowingScope {
+		HashMap<GDScriptParser::VariableNode*, GDScriptParser::DataType> variables;
+		HashMap<GDScriptParser::IdentifierNode*, GDScriptParser::DataType> iterators;
+	};
+	NarrowingScope narrowed_types;
+
 	// Tests for detecting invalid overloading of script members
 	static _FORCE_INLINE_ bool has_member_name_conflict_in_script_class(const StringName &p_name, const GDScriptParser::ClassNode *p_current_class_node, const GDScriptParser::Node *p_member);
 	static _FORCE_INLINE_ bool has_member_name_conflict_in_native_type(const StringName &p_name, const StringName &p_native_type_string);
@@ -93,6 +102,7 @@ class GDScriptAnalyzer {
 	void resolve_constant(GDScriptParser::ConstantNode *p_constant, bool p_is_local);
 	void resolve_parameter(GDScriptParser::ParameterNode *p_parameter);
 	void resolve_if(GDScriptParser::IfNode *p_if);
+	void collect_type_narrowing(GDScriptParser::ExpressionNode* p_expr, bool p_positive, NarrowingScope& r_narrowed);
 	void resolve_for(GDScriptParser::ForNode *p_for);
 	void resolve_while(GDScriptParser::WhileNode *p_while);
 	void resolve_assert(GDScriptParser::AssertNode *p_assert);


### PR DESCRIPTION
for motivation, see: 
https://github.com/godotengine/godot-proposals/issues/8530

It is incredibly beneficial to turn on the unsafe access and unsafe function warnings in GDScript.
(unrelated, Reginleif might turn them on by default later)

However, an incredibly common thing to do in gamedev is `if x is Type` checks. currently, the static analyser doesn't really play well with these warnings.

```gdscript
var node := get_node(...)
if x is Node2D:
    print(x.position)
```
this marks the third line to be type unsafe, and this can even be seen in the editor, as the line number on the left side of the code editor becomes unlit, showing that the analyser could not prove type safety.

however, this operation provably IS safe! it only executes if x is that type, and thus, x's type gets 'narrowed.' 
this PR adds support for narrowing in these cases, along with the code block above:

```gdscript
if x is Node2D and x.get_position().x > 20:
```
narrowing info carries over across `and`. this becomes safe.
(`or` cannot narrow, as there is no way to represent a dual branch for one datatype)

```gdscript
if x is not Node2D: return
print(x.position)
```
this case becomes safe too, as the guard clause narrows the type down.

```gdscript
if x is not Node2D:
    pass
else:
    print(x.position)
```
this case becomes safe too, as the not gets flipped by the else, so we can say the type is indeed provably a Node2D, and thus a valid narrow.

all in all, this makes the aforementioned warnings, much less of a pain in the ass.

**most notably, this PR does not add support for narrowing matches.**
that is a separate feature and will arrive soon.

**note 2: this is an analyser side feature, and does not add code complete.**
that will come VERY soon! as in 'probably today or tomorrow' soon!